### PR TITLE
Update constructor to follow new CarrotQuest credentials policy

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -133,14 +133,13 @@ class Api
      * Constructor
      *
      * @param string $appId Carrot Quest app ID
-     * @param string $key Carrot Quest API key
-     * @param string $secret Carrot Quest API secret key
+     * @param string $token Carrot Quest Auth token
      */
-    public function __construct($appId, $key, $secret)
+    public function __construct($appId, $token)
     {
         $this->curl = curl_init();
         $this->appId = $appId;
-        $this->token = 'app.' . $key . '.' . $secret;
+        $this->token = $token;
     }
 
     /**


### PR DESCRIPTION
Seems that CarrotQuest change tokens policy.
Now individual token can be obtained in cabinet and used as is. So small update.
