### PR TITLE
Fixed translation to query string for get request

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -174,7 +174,7 @@ class Api
     {
         $url = self::URL_PREFIX . '/' . $method . '?auth_token=' . $this->token;
         if ($data && $type == 'get') {
-            $url .= '&' . implode('&', $data);
+            $url .= '&' . http_build_query($data);
         }
 
         $options = [


### PR DESCRIPTION
Fixed translation associative array to query string for get requestUsing implode resulted in incorrect string generation from the array.
Get request with params:
'''
[
'by_user_id' => !$isSystem,
'props' => true,
'props_events' => false,
'props_custom' => false,
'presence_details' => true,
'events' => false,
'segments' => false,
'notes' => false
]
'''
translates to "https://api.carrotquest.io/v1/users/26?auth_token=[token]&1&1&&&1&&&".
You need to use http_build_query for translate associative array to query string